### PR TITLE
AB#170, AB#171

### DIFF
--- a/src/BookLibrary/BookLibrary.csproj
+++ b/src/BookLibrary/BookLibrary.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="2.2.3" />
     <PackageReference Include="AspNetCore.HealthChecks.Publisher.ApplicationInsights" Version="2.2.4" />
     <PackageReference Include="Lamar" Version="3.1.0" />
-    <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="3.1.2" />
+    <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="3.2.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.7.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.0.76" />

--- a/test/BookLibrary.Test/BookLibrary.Test.csproj
+++ b/test/BookLibrary.Test/BookLibrary.Test.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="Moq" Version="4.13.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">


### PR DESCRIPTION
Updated `Lamar.Microsoft.DependencyInjection` and `Microsoft.NET.Test.Sdk`.

`Lamar.Microsoft.DependencyInjection` update was missing in previous build.