### PR TITLE
Enhanced CI/CD pipeline. AB#287, AB#288, AB#290, AB#291

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -76,6 +76,9 @@ stages:
         displayName: 'Create code coverage report'
         enabled: false
 
+      - script: find $(Agent.TempDirectory) -type f -name *.xml
+        displayName: 'List XML files'
+
       - task: PublishCodeCoverageResults@1
         displayName: 'Publish code coverage report'
         inputs:

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -47,12 +47,21 @@ stages:
           packageType: sdk
           version: $(dotnetVersion)
           installationPath: '$(Agent.ToolsDirectory)/dotnet'
+
+      - task: DotNetCoreCLI@2
+        displayName: 'Install ReportGenerator'
+        inputs:
+          command: custom
+          custom: tool
+          arguments: 'install --global dotnet-reportgenerator-globaltool'
+
       - task: DotNetCoreCLI@2
         displayName: Build
         inputs:
           projects: |
             **/BookLibrary.Test.csproj
           arguments: '--configuration $(buildConfiguration)'
+
       - task: DotNetCoreCLI@2
         displayName: Test
         inputs:
@@ -60,6 +69,17 @@ stages:
           projects: |
             **/BookLibrary.Test.csproj
           arguments: '--configuration $(buildConfiguration) --no-build --collect:"XPlat Code Coverage"'
+
+      - script: |
+          reportgenerator -reports:$(Agent.TempDirectory)/**/coverage.cobertura.xml -targetdir:$(Agent.TempDirectory)/CodeCoverage -reporttypes:"Cobertura;HtmlInline_AzurePipelines"
+        displayName: 'Create code coverage report'
+
+      - task: PublishCodeCoverageResults@1
+        displayName: 'Publish code coverage report'
+        inputs:
+          codeCoverageTool: 'cobertura'
+          summaryFileLocation: '$(Agent.TempDirectory)/CodeCoverage/Cobertura.xml'
+
     - job: Docker_Build
       displayName: 'Run docker build'
       condition: |
@@ -82,6 +102,7 @@ stages:
             tags: |
               $(tag)
               latest
+
   - stage: Deploy
     dependsOn: Build
     jobs:

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -13,13 +13,12 @@ pr:
     - src
     - test
 
-# To adopt this build pipeline to your environment, update the following
-# variables:
-# - azureServiceConnection: A reference to your AzureRM service connection
-# - dockerRegistryServiceConnection: A reference to your registry
-# - environment: The name of the environment to deploy to (will be created automatically if it doesn't exist)
+# To adopt this build pipeline to your environment, update the following variables:
+# - azureServiceConnection: Name of your AzureRM service connection
+# - dockerRegistryServiceConnection: Name of your Docker registry service connection
+# - environment: The name of the multi-stage pipeline environment to deploy to (this will be created automatically if it doesn't exist)
 # - imageRepository: The repository to push the image to
-# - webAppName: The name of your web app
+# - webAppName: The name of your web app (i.e. "booklibrary" in "booklibrary.azurewebsites.net")
 variables:
   azureServiceConnection: 'azure/vs'
   buildConfiguration: 'Release'
@@ -27,7 +26,7 @@ variables:
   dockerfilePath: 'src/BookLibrary/Dockerfile'
   dockerRegistryServiceConnection: 'dockerhub/joergjo'
   dotnetVersion: '3.1.x'
-  environment: 'default'
+  environment: 'demo-site'
   imageRepository: 'joergjo/booklibrary-netcore'
   tag: 'ci-$(Build.BuildId)'
   webAppName: 'joergjo-booklibrary'

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -49,14 +49,6 @@ stages:
           installationPath: '$(Agent.ToolsDirectory)/dotnet'
 
       - task: DotNetCoreCLI@2
-        enabled: false
-        displayName: 'Install ReportGenerator'
-        inputs:
-          command: custom
-          custom: tool
-          arguments: 'install --global dotnet-reportgenerator-globaltool'
-
-      - task: DotNetCoreCLI@2
         displayName: Build
         inputs:
           projects: |
@@ -70,14 +62,6 @@ stages:
           projects: |
             **/BookLibrary.Test.csproj
           arguments: '--configuration $(buildConfiguration) --no-build --collect:"XPlat Code Coverage"'
-
-      - script: |
-          reportgenerator -reports:$(Agent.TempDirectory)/*/coverage.cobertura.xml -targetdir:$(Agent.TempDirectory)/CodeCoverage -reporttypes:"Cobertura"
-        displayName: 'Create code coverage report'
-        enabled: false
-
-      - script: find $(Agent.TempDirectory) -type f -name coverage.cobertura.xml -ls
-        displayName: 'List cobertura XML files'
 
       - task: PublishCodeCoverageResults@1
         displayName: 'Publish code coverage report'
@@ -111,7 +95,7 @@ stages:
   - stage: Deploy
     dependsOn: Build
     jobs:
-      - deployment: DeployWebApp
+      - deployment: Deploy_WebApp
         displayName: 'Deploy container image on Azure App Service'
         condition: |
           and

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -58,8 +58,8 @@ stages:
         inputs:
           command: test
           projects: |
-            '**/BookLibrary.Test.csproj'
-          arguments: '--configuration $(buildConfiguration)'
+            **/BookLibrary.Test.csproj
+          arguments: '--configuration $(buildConfiguration) --no-build --collect:"XPlat Code Coverage"'
     - job: Docker_Build
       displayName: 'Run docker build'
       condition: |

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -83,7 +83,7 @@ stages:
         displayName: 'Publish code coverage report'
         inputs:
           codeCoverageTool: 'cobertura'
-          summaryFileLocation: '$(Agent.TempDirectory)/**/coverage.cobertura.xml'
+          summaryFileLocation: '$(Agent.TempDirectory)/*/coverage.cobertura.xml'
 
     - job: Docker_Build
       displayName: 'Run docker build'

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -49,6 +49,7 @@ stages:
           installationPath: '$(Agent.ToolsDirectory)/dotnet'
 
       - task: DotNetCoreCLI@2
+        enabled: false
         displayName: 'Install ReportGenerator'
         inputs:
           command: custom
@@ -73,12 +74,13 @@ stages:
       - script: |
           reportgenerator -reports:$(Agent.TempDirectory)/**/coverage.cobertura.xml -targetdir:$(Agent.TempDirectory)/CodeCoverage -reporttypes:"Cobertura"
         displayName: 'Create code coverage report'
+        enabled: false
 
       - task: PublishCodeCoverageResults@1
         displayName: 'Publish code coverage report'
         inputs:
           codeCoverageTool: 'cobertura'
-          summaryFileLocation: '$(Agent.TempDirectory)/CodeCoverage/Cobertura.xml'
+          summaryFileLocation: '$(Agent.TempDirectory)/**/coverage.cobertura.xml'
 
     - job: Docker_Build
       displayName: 'Run docker build'

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -76,8 +76,8 @@ stages:
         displayName: 'Create code coverage report'
         enabled: false
 
-      - script: find $(Agent.TempDirectory) -type f -name *.xml
-        displayName: 'List XML files'
+      - script: find $(Agent.TempDirectory) -type f -name coverage.cobertura.xml -ls
+        displayName: 'List cobertura XML files'
 
       - task: PublishCodeCoverageResults@1
         displayName: 'Publish code coverage report'

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -71,7 +71,7 @@ stages:
           arguments: '--configuration $(buildConfiguration) --no-build --collect:"XPlat Code Coverage"'
 
       - script: |
-          reportgenerator -reports:$(Agent.TempDirectory)/**/coverage.cobertura.xml -targetdir:$(Agent.TempDirectory)/CodeCoverage -reporttypes:"Cobertura;HtmlInline_AzurePipelines"
+          reportgenerator -reports:$(Agent.TempDirectory)/**/coverage.cobertura.xml -targetdir:$(Agent.TempDirectory)/CodeCoverage -reporttypes:"Cobertura"
         displayName: 'Create code coverage report'
 
       - task: PublishCodeCoverageResults@1

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -72,7 +72,7 @@ stages:
           arguments: '--configuration $(buildConfiguration) --no-build --collect:"XPlat Code Coverage"'
 
       - script: |
-          reportgenerator -reports:$(Agent.TempDirectory)/**/coverage.cobertura.xml -targetdir:$(Agent.TempDirectory)/CodeCoverage -reporttypes:"Cobertura"
+          reportgenerator -reports:$(Agent.TempDirectory)/*/coverage.cobertura.xml -targetdir:$(Agent.TempDirectory)/CodeCoverage -reporttypes:"Cobertura"
         displayName: 'Create code coverage report'
         enabled: false
 

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -1,7 +1,4 @@
 trigger:
-  branches:
-    include:
-    - master
   paths:
     include:
     - src
@@ -20,7 +17,7 @@ pr:
 # variables:
 # - azureServiceConnection: A reference to your AzureRM service connection
 # - dockerRegistryServiceConnection: A reference to your registry
-# - environment: Create an empty environment called 'default', as Deploy stages require it
+# - environment: The name of the environment to deploy to (will be created automatically if it doesn't exist)
 # - imageRepository: The repository to push the image to
 # - webAppName: The name of your web app
 variables:
@@ -39,14 +36,13 @@ variables:
 stages:
   - stage: Build
     jobs:
-    - job: PR_Validation
-      displayName: 'Pull Request Validation'
-      condition: eq(variables['Build.Reason'], 'PullRequest')
+    - job: Dotnet_Build
+      displayName: 'Run dotnet build and test'
       pool:
         vmImageName: $(vmImageName)
       steps:
       - task: UseDotNet@2
-        displayName: 'Install latest .NET Core SDK'
+        displayName: 'Install .NET Core SDK $(dotnetVersion)'
         inputs:
           packageType: sdk
           version: $(dotnetVersion)
@@ -62,16 +58,21 @@ stages:
         inputs:
           command: test
           projects: |
-            **/BookLibrary.Test.csproj
+            '**/BookLibrary.Test.csproj'
           arguments: '--configuration $(buildConfiguration)'
-    - job: Build_Container_Images
-      displayName: 'Build container image'
-      condition: in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual')
+    - job: Docker_Build
+      displayName: 'Run docker build'
+      condition: |
+        and
+        (
+          in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual'),
+          eq(variables['Build.SourceBranchName'], 'master')
+        )
       pool:
         vmImageName: $(vmImageName)
       steps:
         - task: Docker@2
-          displayName: 'Build and push image to container'
+          displayName: 'Build and push image to container registry'
           inputs:
             command: buildAndPush
             repository: $(imageRepository)
@@ -85,8 +86,13 @@ stages:
     dependsOn: Build
     jobs:
       - deployment: DeployWebApp
-        displayName: 'Deploy Web App on App Service'
-        condition: in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual')
+        displayName: 'Deploy container image on Azure App Service'
+        condition: |
+          and
+          (
+            in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual'),
+            eq(variables['Build.SourceBranchName'], 'master')
+          )
         pool:
           vmImageName: $(vmImageName)
         environment: $(environment)

--- a/.gitignore
+++ b/.gitignore
@@ -261,4 +261,5 @@ __pycache__/
 *.pyc
 
 # Project specific
-**/wwwroot/lib
+**/wwwroot/lib/
+[Cc]ode[Cc]overage/

--- a/src/BookLibrary/BookLibrary.csproj
+++ b/src/BookLibrary/BookLibrary.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="3.0.1" />
     <PackageReference Include="AspNetCore.HealthChecks.Publisher.ApplicationInsights" Version="3.0.3" />
-    <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="4.0.2" />
+    <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="4.1.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.12.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.10.0" />
   </ItemGroup>

--- a/test/BookLibrary.Test/BookLibrary.Test.csproj
+++ b/test/BookLibrary.Test/BookLibrary.Test.csproj
@@ -7,7 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="1.1.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
- CI builds are now triggered for updates on `src` and `test` on _every_ branch
- CI builds now create code coverage reports using [coverlet](https://github.com/tonerdo/coverlet#vstest-integration-preferred-due-to-know-issue) 
- Container image build and Web app deployment are still only run for updates on `master`
- Updated Lamar to [4.1.0](https://github.com/JasperFx/lamar/releases/tag/4.1.0)
- Updated coverlet.collector to [1.2.0](https://github.com/tonerdo/coverlet/blob/master/Documentation/Changelog.md#changelog)
