### PR TITLE
Reduced "Build" stage to one job. AB#292

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -35,7 +35,7 @@ variables:
 stages:
   - stage: Build
     jobs:
-    - job: Dotnet_Build
+    - job: Build
       displayName: 'Run dotnet build and test'
       pool:
         vmImageName: $(vmImageName)
@@ -68,33 +68,28 @@ stages:
           codeCoverageTool: 'cobertura'
           summaryFileLocation: '$(Agent.TempDirectory)/*/coverage.cobertura.xml'
 
-    - job: Docker_Build
-      displayName: 'Run docker build'
-      condition: |
-        and
-        (
-          in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual'),
-          eq(variables['Build.SourceBranchName'], 'master')
-        )
-      pool:
-        vmImageName: $(vmImageName)
-      steps:
-        - task: Docker@2
-          displayName: 'Build and push image to container registry'
-          inputs:
-            command: buildAndPush
-            repository: $(imageRepository)
-            dockerfile: $(dockerfilePath)
-            buildContext: $(buildContext)
-            containerRegistry: $(dockerRegistryServiceConnection)
-            tags: |
-              $(tag)
-              latest
+      - task: Docker@2
+        displayName: 'Build and push image to container registry'
+        inputs:
+          command: buildAndPush
+          repository: $(imageRepository)
+          dockerfile: $(dockerfilePath)
+          buildContext: $(buildContext)
+          containerRegistry: $(dockerRegistryServiceConnection)
+          tags: |
+            $(tag)
+            latest
+        condition: |
+          and
+          (
+            in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Manual'),
+            eq(variables['Build.SourceBranchName'], 'master')
+          )
 
   - stage: Deploy
     dependsOn: Build
     jobs:
-      - deployment: Deploy_WebApp
+      - deployment: Deploy
         displayName: 'Deploy container image on Azure App Service'
         condition: |
           and


### PR DESCRIPTION
The job for Docker builds has been removed, since it was not intended to run this potentially in parallel to the first job. This was a left over artifact of the way the pipelines was previously structured. 