### PR TITLE
fix: call gulp directly, don't use npx. AB#352

### DIFF
--- a/src/BookLibrary/BookLibrary.csproj
+++ b/src/BookLibrary/BookLibrary.csproj
@@ -17,7 +17,7 @@
 
   <Target Name="PrepublishScript" BeforeTargets="PrepareForPublish">
     <Exec Command="npm install" />
-    <Exec Command="npx gulp" />
+    <Exec Command="node_modules/.bin/gulp" />
   </Target>
 
 </Project>


### PR DESCRIPTION
It seems that npx is not available on App Services on Windows, and running `npm i -g npx` is not permissible.